### PR TITLE
Use bash shell for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 #
+SHELL := /bin/bash
 
 NAME = main
 


### PR DESCRIPTION
On Ubuntu the default shell is Dash. Dash apparently does not do string substitution. When doing `make` one gets an error:
`/bin/sh: 1: Bad substitution`

To fix this one need to tell make to use Bash.